### PR TITLE
Fixes auxmos fire spread on based linux servers.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -75,7 +75,7 @@
 	priority = 0
 	name = "Condensation"
 	id = "condense"
-	exclude = TRUE
+	//exclude = TRUE
 	var/datum/reagent/condensing_reagent
 
 /datum/gas_reaction/condensation/New(datum/reagent/R)
@@ -114,7 +114,7 @@
 //tritium combustion: combustion of oxygen and tritium (treated as hydrocarbons). creates hotspots. exothermic
 /datum/gas_reaction/tritfire
 	priority = -1 //fire should ALWAYS be last, but tritium fires happen before plasma fires
-	exclude = TRUE // generic fire now takes care of this
+	//exclude = TRUE // generic fire now takes care of this
 	name = "Tritium Combustion"
 	id = "tritfire"
 
@@ -196,7 +196,7 @@
 /datum/gas_reaction/plasmafire
 	priority = -2 //fire should ALWAYS be last, but plasma fires happen after tritium fires
 	name = "Plasma Combustion"
-	exclude = TRUE // generic fire now takes care of this
+	//exclude = TRUE // generic fire now takes care of this
 	id = "plasmafire"
 
 /datum/gas_reaction/plasmafire/init_reqs()

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -21,7 +21,7 @@ export SPACEMAN_DMM_VERSION=suite-1.7
 export PYTHON_VERSION=3.7.9
 
 # Auxmos git tag
-export AUXMOS_VERSION=v0.3.0
+export AUXMOS_VERSION=v0.3.2
 
 # Extools git tag
 export EXTOOLS_VERSION=v0.0.7


### PR DESCRIPTION
There is an issue with fires failing to spread on linux servers. This will hopefully fix everything with some efforts and help from Putnam#0852.

`exclude = TRUE` seems to be the issue with linux based servers for whatever reason. This just comments it out.

## Changelog

:cl: Curiosity
fix: Fixes Auxmos fires
/:cl:

